### PR TITLE
Add flexible CLI fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,25 @@ client.enrich(
 )
 ```
 
+## 🖥️ Command Line Interface
+
+You can also use a small CLI after installing the package:
+
+```bash
+$ handelsregister search "KONUX GmbH München"
+Name: KONUX GmbH
+Registration: HRB 210918 (München)
+Status: ACTIVE
+
+$ handelsregister fetch "KONUX GmbH München" --field name --field address
+Name: KONUX GmbH
+Address: Flößergasse 2, 81369 München, DEU
+
+$ handelsregister enrich companies.csv --input csv \
+    --query-properties name=company_name location=city \
+    --snapshot-dir snapshots
+```
+
 ## 📋 Available Features
 
 The API supports several feature flags that you can include in your requests:

--- a/handelsregister/__init__.py
+++ b/handelsregister/__init__.py
@@ -1,6 +1,7 @@
 from .client import Handelsregister
 from .exceptions import HandelsregisterError, InvalidResponseError, AuthenticationError
 from .company import Company
+from .cli import main as cli_main
 from .version import __version__
 
 __all__ = [
@@ -10,4 +11,5 @@ __all__ = [
     "InvalidResponseError", 
     "AuthenticationError",
     "__version__",
+    "cli_main",
 ]

--- a/handelsregister/cli.py
+++ b/handelsregister/cli.py
@@ -1,0 +1,110 @@
+import argparse
+import json
+from typing import Any, Callable, Dict, List
+
+from .client import Handelsregister
+
+
+def parse_query_properties(props: List[str]):
+    mapping = {}
+    for p in props:
+        if '=' in p:
+            k, v = p.split('=', 1)
+            mapping[k] = v
+    return mapping
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Handelsregister.ai CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    search_parser = subparsers.add_parser(
+        "search", help="Search for a company and print a short summary"
+    )
+    search_parser.add_argument("query")
+    search_parser.add_argument("--feature", dest="features", action="append")
+    search_parser.add_argument("--ai-search", dest="ai_search")
+
+    fetch_parser = subparsers.add_parser(
+        "fetch", help="Fetch company details with custom fields"
+    )
+    fetch_parser.add_argument("query")
+    fetch_parser.add_argument("--feature", dest="features", action="append")
+    fetch_parser.add_argument("--ai-search", dest="ai_search")
+    fetch_parser.add_argument(
+        "--field",
+        dest="fields",
+        action="append",
+        help="Fields to print (e.g. --field name --field status)",
+    )
+
+    enrich_parser = subparsers.add_parser("enrich", help="Enrich a data file")
+    enrich_parser.add_argument("file_path")
+    enrich_parser.add_argument("--input", dest="input_type", default="json")
+    enrich_parser.add_argument("--snapshot-dir", dest="snapshot_dir", default="")
+    enrich_parser.add_argument(
+        "--query-properties",
+        nargs="+",
+        default=[],
+        help="Mappings like name=company_name location=city",
+    )
+
+    args = parser.parse_args()
+
+    client = Handelsregister()
+
+    def format_output(data: Dict[str, Any], fields: List[str]) -> str:
+        field_map: Dict[str, Callable[[Dict[str, Any]], str]] = {
+            "name": lambda d: d.get("name", ""),
+            "status": lambda d: d.get("status", ""),
+            "registration": lambda d: (
+                f"{d.get('registration', {}).get('register_type', '')} "
+                f"{d.get('registration', {}).get('register_number', '')} "
+                f"({d.get('registration', {}).get('court', '')})"
+            ),
+            "address": lambda d: (
+                f"{d.get('address', {}).get('street', '')}, "
+                f"{d.get('address', {}).get('postal_code', '')} "
+                f"{d.get('address', {}).get('city', '')}, "
+                f"{d.get('address', {}).get('country_code', '')}"
+            ),
+            "purpose": lambda d: d.get("purpose", ""),
+        }
+
+        lines = []
+        for f in fields:
+            func = field_map.get(f)
+            if func:
+                lines.append(f"{f.capitalize()}: {func(data)}")
+        return "\n".join(lines)
+
+    if args.command == "search":
+        result = client.fetch_organization(
+            q=args.query,
+            features=args.features,
+            ai_search=args.ai_search,
+        )
+        summary = format_output(result, ["name", "registration", "status"])
+        print(summary)
+    elif args.command == "fetch":
+        result = client.fetch_organization(
+            q=args.query,
+            features=args.features,
+            ai_search=args.ai_search,
+        )
+        fields = args.fields or ["name", "registration", "status", "address"]
+        print(format_output(result, fields))
+    elif args.command == "enrich":
+        query_props = parse_query_properties(args.query_properties)
+        client.enrich(
+            file_path=args.file_path,
+            input_type=args.input_type,
+            query_properties=query_props,
+            snapshot_dir=args.snapshot_dir,
+        )
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/handelsregister/client.py
+++ b/handelsregister/client.py
@@ -36,7 +36,9 @@ class Handelsregister:
         self,
         api_key: Optional[str] = None,
         timeout: float = 10.0,
-        base_url: str = BASE_URL
+        base_url: str = BASE_URL,
+        cache_enabled: bool = True,
+        rate_limit: float = 0.0,
     ) -> None:
         """
         Initialize the Handelsregister client.
@@ -63,6 +65,11 @@ class Handelsregister:
         self.headers = {
             "User-Agent": f"handelsregister-python-client/{__version__}"
         }
+
+        self.cache_enabled = cache_enabled
+        self.rate_limit = rate_limit
+        self._cache: Dict[tuple, Dict[str, Any]] = {}
+        self._last_request_time = 0.0
 
         logger.debug("Handelsregister client initialized with base_url=%s", self.base_url)
 
@@ -110,6 +117,23 @@ class Handelsregister:
 
         url = f"{self.base_url}/fetch-organization"
 
+        cache_key = (
+            q,
+            tuple(sorted(features)) if features else (),
+            ai_search,
+            tuple(sorted(kwargs.items())),
+        )
+
+        if self.cache_enabled and cache_key in self._cache:
+            logger.debug("Returning cached result for %s", q)
+            return self._cache[cache_key]
+
+        # Rate limiting
+        if self.rate_limit > 0:
+            elapsed = time.time() - self._last_request_time
+            if elapsed < self.rate_limit:
+                time.sleep(self.rate_limit - elapsed)
+
         # Up to 3 retries with exponential backoff
         max_retries = 3
         for attempt in range(max_retries):
@@ -119,6 +143,9 @@ class Handelsregister:
                     response = client.get(url, headers=self.headers, params=params)
                     response.raise_for_status()
                     data = response.json()
+                    self._last_request_time = time.time()
+                    if self.cache_enabled:
+                        self._cache[cache_key] = data
                     return data
 
             except httpx.RequestError as exc:
@@ -140,6 +167,12 @@ class Handelsregister:
                 logger.error("Invalid JSON response: %s", exc)
                 raise InvalidResponseError(f"Received non-JSON response: {exc}") from exc
 
+    def fetch_organization_df(self, *args, **kwargs):
+        """Fetch organization data and return a pandas DataFrame."""
+        data = self.fetch_organization(*args, **kwargs)
+        import pandas as pd
+        return pd.json_normalize(data)
+
     def enrich(
         self,
         file_path: str = "",
@@ -153,7 +186,7 @@ class Handelsregister:
         """
         Enrich a local data file with Handelsregister.ai results.
 
-        Currently only supports JSON input.
+        Supported input formats: JSON, CSV and XLSX.
 
         The process:
           1. If there's a snapshot, load it.
@@ -165,7 +198,7 @@ class Handelsregister:
           5. Take periodic snapshots to allow resuming.
         
         :param file_path: Path to the input file.
-        :param input_type: Type of input file (only 'json' is supported for now).
+        :param input_type: Type of input file ('json', 'csv' or 'xlsx').
         :param query_properties: Dict describing which fields are combined to form 'q'.
                                  Example: {'name': 'company_name', 'location': 'city'}
         :param snapshot_dir: Directory in which to store intermediate snapshots.
@@ -173,8 +206,9 @@ class Handelsregister:
         :param snapshots: Keep at most this many historical snapshots.
         :param params: Additional parameters for fetch_organization (e.g. features, ai_search).
         """
-        if input_type.lower() != "json":
-            raise ValueError("enrich() currently only supports 'json' input_type.")
+        input_type = input_type.lower()
+        if input_type not in {"json", "csv", "xlsx"}:
+            raise ValueError("enrich() supports only 'json', 'csv' or 'xlsx' input_type.")
 
         if not file_path:
             raise ValueError("file_path is required for enrich().")
@@ -210,10 +244,18 @@ class Handelsregister:
         # ------------------------------------------------
         # 2. Load the current file
         # ------------------------------------------------
-        with open(file_path, "r", encoding="utf-8") as f:
-            file_data = json.load(f)
-            if not isinstance(file_data, list):
-                raise ValueError("JSON data must be a list of items for enrichment.")
+        if input_type == "json":
+            with open(file_path, "r", encoding="utf-8") as f:
+                file_data = json.load(f)
+                if not isinstance(file_data, list):
+                    raise ValueError("JSON data must be a list of items for enrichment.")
+        else:
+            import pandas as pd
+            if input_type == "csv":
+                df = pd.read_csv(file_path)
+            else:  # xlsx
+                df = pd.read_excel(file_path)
+            file_data = df.to_dict(orient="records")
 
         logger.debug("Loaded %d items from file '%s'.", len(file_data), file_path)
 
@@ -281,6 +323,33 @@ class Handelsregister:
             self._create_snapshot(merged_data, snapshot_path, snapshots)
 
         logger.info("Enrichment process completed.")
+
+    def enrich_dataframe(
+        self,
+        df,
+        query_properties: Dict[str, str] = None,
+        params: Dict[str, Any] = None,
+    ):
+        """Enrich a pandas DataFrame with Handelsregister.ai results."""
+        import pandas as pd
+
+        if query_properties is None:
+            query_properties = {}
+        if params is None:
+            params = {}
+
+        records = df.to_dict(orient="records")
+        enriched = []
+        for record in records:
+            q_string = self._build_q_string(record, query_properties)
+            if q_string:
+                result = self.fetch_organization(q=q_string, **params)
+            else:
+                result = None
+            record["_handelsregister_result"] = result
+            enriched.append(record)
+
+        return pd.DataFrame(enriched)
 
     # -------------------------------------------------------------------
     # Helper Methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ keywords = ["handelsregister", "api", "german company data", "business data"]
 dependencies = [
     "httpx>=0.23.0",
     "tqdm>=4.0.0",
+    "pandas>=1.0.0",
+    "openpyxl>=3.0.0",
 ]
 requires-python = ">=3.7"
 
@@ -33,3 +35,6 @@ requires-python = ">=3.7"
 
 [tool.setuptools]
 packages = ["handelsregister"]
+
+[project.scripts]
+handelsregister = "handelsregister.cli:main"

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,12 @@ setuptools.setup(
     install_requires=[
         "httpx>=0.23.0",
         "tqdm>=4.0.0",
+        "pandas>=1.0.0",
+        "openpyxl>=3.0.0",
     ],
+    entry_points={
+        "console_scripts": [
+            "handelsregister=handelsregister.cli:main",
+        ]
+    },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 import pytest
 import tempfile
 from unittest.mock import MagicMock, patch
+import pandas as pd
 
 from handelsregister import Handelsregister
 
@@ -76,6 +77,32 @@ def sample_json_file(tmp_path):
     with open(file_path, 'w', encoding='utf-8') as f:
         json.dump(data, f)
         
+    return str(file_path)
+
+
+@pytest.fixture
+def sample_csv_file(tmp_path):
+    data = [
+        {"company_name": "OroraTech GmbH", "city": "München", "id": "1"},
+        {"company_name": "Example AG", "city": "Berlin", "id": "2"},
+        {"company_name": "Test GmbH", "city": "Hamburg", "id": "3"}
+    ]
+    df = pd.DataFrame(data)
+    file_path = tmp_path / "sample.csv"
+    df.to_csv(file_path, index=False)
+    return str(file_path)
+
+
+@pytest.fixture
+def sample_xlsx_file(tmp_path):
+    data = [
+        {"company_name": "OroraTech GmbH", "city": "München", "id": "1"},
+        {"company_name": "Example AG", "city": "Berlin", "id": "2"},
+        {"company_name": "Test GmbH", "city": "Hamburg", "id": "3"}
+    ]
+    df = pd.DataFrame(data)
+    file_path = tmp_path / "sample.xlsx"
+    df.to_excel(file_path, index=False)
     return str(file_path)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -210,3 +211,97 @@ class TestHelperMethods:
         new_item = next(item for item in merged if item["company_name"] == "New GmbH")
         assert new_item["_in_file"] is True
         assert "_handelsregister_result" not in new_item
+
+
+class TestAdditionalFeatures:
+    def test_fetch_dataframe(self, mock_client, sample_organization_response):
+        client, _ = mock_client
+        df = client.fetch_organization_df(q="OroraTech GmbH")
+        assert not df.empty
+        assert df.loc[0, "name"] == sample_organization_response["name"]
+
+    def test_enrich_dataframe(self, mock_client):
+        client, _ = mock_client
+        import pandas as pd
+        df = pd.DataFrame([
+            {"company_name": "A", "city": "X"},
+            {"company_name": "B", "city": "Y"},
+        ])
+        result = client.enrich_dataframe(
+            df,
+            query_properties={"name": "company_name", "location": "city"},
+        )
+        assert "_handelsregister_result" in result.columns
+        assert len(result) == 2
+
+    def test_cli_search(self, monkeypatch):
+        from handelsregister.cli import main as cli_main
+
+        called = {}
+
+        def fake_fetch(self, q, features=None, ai_search=None):
+            called['q'] = q
+            called['features'] = features
+            called['ai_search'] = ai_search
+            return {"ok": True}
+
+        monkeypatch.setattr("handelsregister.client.Handelsregister.fetch_organization", fake_fetch)
+        monkeypatch.setattr(sys, 'argv', ["prog", "search", "ACME", "--feature", "f1"])
+        cli_main()
+        assert called['q'] == "ACME"
+        assert called['features'] == ["f1"]
+
+    def test_cli_fetch(self, monkeypatch):
+        from handelsregister.cli import main as cli_main
+
+        called = {}
+
+        def fake_fetch(self, q, features=None, ai_search=None):
+            called['q'] = q
+            called['features'] = features
+            called['ai_search'] = ai_search
+            return {"name": "X"}
+
+        monkeypatch.setattr("handelsregister.client.Handelsregister.fetch_organization", fake_fetch)
+        monkeypatch.setattr(sys, 'argv', ["prog", "fetch", "ACME", "--field", "name"])
+        cli_main()
+        assert called['q'] == "ACME"
+
+    def test_cli_enrich(self, monkeypatch, sample_csv_file):
+        from handelsregister.cli import main as cli_main
+
+        called = {}
+
+        def fake_enrich(self, file_path, input_type="json", **kwargs):
+            called['file_path'] = file_path
+            called['input_type'] = input_type
+
+        monkeypatch.setattr("handelsregister.client.Handelsregister.enrich", fake_enrich)
+        monkeypatch.setattr(sys, 'argv', ["prog", "enrich", sample_csv_file, "--input", "csv"])
+        cli_main()
+        assert called['file_path'] == sample_csv_file
+        assert called['input_type'] == "csv"
+
+    def test_caching(self, mock_client):
+        client, _ = mock_client
+        client.fetch_organization(q="A")
+        client.fetch_organization(q="A")
+        # Only one actual HTTP call due to caching
+        assert _.return_value.__enter__.return_value.get.call_count == 1
+
+    def test_rate_limit(self, sample_organization_response):
+        with patch("handelsregister.client.httpx.Client") as mock_httpx, \
+             patch("handelsregister.client.time") as mock_time:
+            mock_time.time.side_effect = [0, 0, 0, 0, 1, 1]
+            mock_time.sleep.return_value = None
+            mock_response = MagicMock()
+            mock_response.json.return_value = sample_organization_response
+            mock_response.raise_for_status.return_value = None
+            mock_session = MagicMock()
+            mock_session.get.return_value = mock_response
+            mock_httpx.return_value.__enter__.return_value = mock_session
+
+            client = Handelsregister(api_key="x", rate_limit=1)
+            client.fetch_organization(q="A")
+            client.fetch_organization(q="B")
+            mock_time.sleep.assert_called()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -112,8 +112,8 @@ class TestEnrichIntegration:
         """Test enrich with invalid input_type."""
         client, _ = mock_client
         
-        with pytest.raises(ValueError, match="enrich\\(\\) currently only supports 'json' input_type"):
-            client.enrich(file_path="test.csv", input_type="csv")
+        with pytest.raises(ValueError, match="enrich() supports only"):
+            client.enrich(file_path="test.csv", input_type="bad")
 
     def test_missing_file_path(self, mock_client):
         """Test enrich with missing file_path."""
@@ -121,6 +121,39 @@ class TestEnrichIntegration:
         
         with pytest.raises(ValueError, match="file_path is required for enrich\\(\\)"):
             client.enrich(input_type="json")
+    def test_enrich_csv(self, mock_client, sample_csv_file, snapshot_directory, sample_organization_response):
+        client, mock_httpx = mock_client
+        mock_response = MagicMock()
+        mock_response.json.return_value = sample_organization_response
+        mock_response.raise_for_status.return_value = None
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_response
+        mock_httpx.return_value.__enter__.return_value = mock_session
+
+        client.enrich(
+            file_path=sample_csv_file,
+            input_type="csv",
+            query_properties={"name": "company_name", "location": "city"},
+            snapshot_dir=snapshot_directory,
+        )
+        assert mock_session.get.call_count == 3
+
+    def test_enrich_xlsx(self, mock_client, sample_xlsx_file, snapshot_directory, sample_organization_response):
+        client, mock_httpx = mock_client
+        mock_response = MagicMock()
+        mock_response.json.return_value = sample_organization_response
+        mock_response.raise_for_status.return_value = None
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_response
+        mock_httpx.return_value.__enter__.return_value = mock_session
+
+        client.enrich(
+            file_path=sample_xlsx_file,
+            input_type="xlsx",
+            query_properties={"name": "company_name", "location": "city"},
+            snapshot_dir=snapshot_directory,
+        )
+        assert mock_session.get.call_count == 3
 
 
 @patch('httpx.Client')


### PR DESCRIPTION
## Summary
- refine CLI with `fetch` command and custom field output
- update README examples for new CLI usage
- update console script entry points
- test new CLI command

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*