### PR TITLE
Enhance CLI and enrichment output

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,21 @@ client.enrich(
 )
 ```
 
+## 🖥️ Command Line Interface
+
+You can also use a small CLI after installing the package:
+
+```bash
+$ handelsregister fetch "KONUX GmbH München" --field name --field status
+name: KONUX GmbH
+status: ACTIVE
+
+$ handelsregister enrich companies.csv --input csv \
+    --query-properties name=company_name location=city \
+    --snapshot-dir snapshots
+    # default output will be companies_handelsregister_ai_enriched.csv
+```
+
 ## 📋 Available Features
 
 The API supports several feature flags that you can include in your requests:

--- a/handelsregister/__init__.py
+++ b/handelsregister/__init__.py
@@ -1,6 +1,7 @@
 from .client import Handelsregister
 from .exceptions import HandelsregisterError, InvalidResponseError, AuthenticationError
 from .company import Company
+from .cli import main as cli_main
 from .version import __version__
 
 __all__ = [
@@ -10,4 +11,5 @@ __all__ = [
     "InvalidResponseError", 
     "AuthenticationError",
     "__version__",
+    "cli_main",
 ]

--- a/handelsregister/cli.py
+++ b/handelsregister/cli.py
@@ -1,0 +1,88 @@
+import argparse
+import json
+from typing import List
+
+from .client import Handelsregister
+
+
+def parse_query_properties(props: List[str]):
+    mapping = {}
+    for p in props:
+        if '=' in p:
+            k, v = p.split('=', 1)
+            mapping[k] = v
+    return mapping
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Handelsregister.ai CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    fetch_parser = subparsers.add_parser("fetch", help="Fetch and display company information")
+    fetch_parser.add_argument("query")
+    fetch_parser.add_argument("--feature", dest="features", action="append")
+    fetch_parser.add_argument("--ai-search", dest="ai_search")
+    fetch_parser.add_argument(
+        "--field",
+        dest="fields",
+        action="append",
+        help="Fields to display from the result (dot notation)",
+    )
+
+    enrich_parser = subparsers.add_parser("enrich", help="Enrich a data file")
+    enrich_parser.add_argument("file_path")
+    enrich_parser.add_argument("--input", dest="input_type", default="json")
+    enrich_parser.add_argument("--output", dest="output_path")
+    enrich_parser.add_argument("--output-type", dest="output_type")
+    enrich_parser.add_argument("--snapshot-dir", dest="snapshot_dir", default="")
+    enrich_parser.add_argument(
+        "--query-properties",
+        nargs="+",
+        default=[],
+        help="Mappings like name=company_name location=city",
+    )
+
+    args = parser.parse_args()
+
+    client = Handelsregister()
+
+    if args.command == "fetch":
+        result = client.fetch_organization(
+            q=args.query,
+            features=args.features,
+            ai_search=args.ai_search,
+        )
+        fields = args.fields or ["name", "registration.register_number", "status"]
+
+        def get_value(data, path):
+            parts = path.split(".")
+            val = data
+            for p in parts:
+                if isinstance(val, dict):
+                    val = val.get(p)
+                else:
+                    val = None
+                if val is None:
+                    break
+            return val
+
+        lines = []
+        for field in fields:
+            lines.append(f"{field}: {get_value(result, field)}")
+        print("\n".join(lines))
+    elif args.command == "enrich":
+        query_props = parse_query_properties(args.query_properties)
+        client.enrich(
+            file_path=args.file_path,
+            input_type=args.input_type,
+            output_path=args.output_path,
+            output_type=args.output_type,
+            query_properties=query_props,
+            snapshot_dir=args.snapshot_dir,
+        )
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/handelsregister/version.py
+++ b/handelsregister/version.py
@@ -2,4 +2,4 @@
 Versionsinformationen für das Handelsregister AI SDK.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "handelsregister"
-version = "0.1.0"
+version = "0.2"
 description = "Python SDK für den Zugriff auf die Handelsregister AI API"
 readme = "README.md"
 authors = [
@@ -24,6 +24,8 @@ keywords = ["handelsregister", "api", "german company data", "business data"]
 dependencies = [
     "httpx>=0.23.0",
     "tqdm>=4.0.0",
+    "pandas>=1.0.0",
+    "openpyxl>=3.0.0",
 ]
 requires-python = ">=3.7"
 
@@ -33,3 +35,6 @@ requires-python = ">=3.7"
 
 [tool.setuptools]
 packages = ["handelsregister"]
+
+[project.scripts]
+handelsregister = "handelsregister.cli:main"

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,12 @@ setuptools.setup(
     install_requires=[
         "httpx>=0.23.0",
         "tqdm>=4.0.0",
+        "pandas>=1.0.0",
+        "openpyxl>=3.0.0",
     ],
+    entry_points={
+        "console_scripts": [
+            "handelsregister=handelsregister.cli:main",
+        ]
+    },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 import pytest
 import tempfile
 from unittest.mock import MagicMock, patch
+import pandas as pd
 
 from handelsregister import Handelsregister
 
@@ -76,6 +77,32 @@ def sample_json_file(tmp_path):
     with open(file_path, 'w', encoding='utf-8') as f:
         json.dump(data, f)
         
+    return str(file_path)
+
+
+@pytest.fixture
+def sample_csv_file(tmp_path):
+    data = [
+        {"company_name": "OroraTech GmbH", "city": "München", "id": "1"},
+        {"company_name": "Example AG", "city": "Berlin", "id": "2"},
+        {"company_name": "Test GmbH", "city": "Hamburg", "id": "3"}
+    ]
+    df = pd.DataFrame(data)
+    file_path = tmp_path / "sample.csv"
+    df.to_csv(file_path, index=False)
+    return str(file_path)
+
+
+@pytest.fixture
+def sample_xlsx_file(tmp_path):
+    data = [
+        {"company_name": "OroraTech GmbH", "city": "München", "id": "1"},
+        {"company_name": "Example AG", "city": "Berlin", "id": "2"},
+        {"company_name": "Test GmbH", "city": "Hamburg", "id": "3"}
+    ]
+    df = pd.DataFrame(data)
+    file_path = tmp_path / "sample.xlsx"
+    df.to_excel(file_path, index=False)
     return str(file_path)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -210,3 +211,85 @@ class TestHelperMethods:
         new_item = next(item for item in merged if item["company_name"] == "New GmbH")
         assert new_item["_in_file"] is True
         assert "_handelsregister_result" not in new_item
+
+
+class TestAdditionalFeatures:
+    def test_fetch_dataframe(self, mock_client, sample_organization_response):
+        client, _ = mock_client
+        df = client.fetch_organization_df(q="OroraTech GmbH")
+        assert not df.empty
+        assert df.loc[0, "name"] == sample_organization_response["name"]
+
+    def test_enrich_dataframe(self, mock_client):
+        client, _ = mock_client
+        import pandas as pd
+        df = pd.DataFrame([
+            {"company_name": "A", "city": "X"},
+            {"company_name": "B", "city": "Y"},
+        ])
+        result = client.enrich_dataframe(
+            df,
+            query_properties={"name": "company_name", "location": "city"},
+        )
+        assert "_handelsregister_result" in result.columns
+        assert len(result) == 2
+
+    def test_cli_fetch(self, monkeypatch):
+        from handelsregister.cli import main as cli_main
+
+        called = {}
+
+        def fake_fetch(self, q, features=None, ai_search=None):
+            called['q'] = q
+            called['features'] = features
+            called['ai_search'] = ai_search
+            return {"ok": True}
+
+        monkeypatch.setattr("handelsregister.client.Handelsregister.fetch_organization", fake_fetch)
+        monkeypatch.setattr(sys, 'argv', ["prog", "fetch", "ACME", "--feature", "f1", "--field", "name"])
+        cli_main()
+        assert called['q'] == "ACME"
+        assert called['features'] == ["f1"]
+
+    def test_cli_enrich(self, monkeypatch, sample_csv_file):
+        from handelsregister.cli import main as cli_main
+
+        called = {}
+
+        def fake_enrich(self, file_path, input_type="json", output_path=None, output_type=None, **kwargs):
+            called['file_path'] = file_path
+            called['input_type'] = input_type
+            called['output_path'] = output_path
+            called['output_type'] = output_type
+
+        monkeypatch.setattr("handelsregister.client.Handelsregister.enrich", fake_enrich)
+        monkeypatch.setattr(sys, 'argv', ["prog", "enrich", sample_csv_file, "--input", "csv", "--output", "out.csv", "--output-type", "csv"])
+        cli_main()
+        assert called['file_path'] == sample_csv_file
+        assert called['input_type'] == "csv"
+        assert called['output_path'] == "out.csv"
+        assert called['output_type'] == "csv"
+
+    def test_caching(self, mock_client):
+        client, _ = mock_client
+        client.fetch_organization(q="A")
+        client.fetch_organization(q="A")
+        # Only one actual HTTP call due to caching
+        assert _.return_value.__enter__.return_value.get.call_count == 1
+
+    def test_rate_limit(self, sample_organization_response):
+        with patch("handelsregister.client.httpx.Client") as mock_httpx, \
+             patch("handelsregister.client.time") as mock_time:
+            mock_time.time.side_effect = [0, 0, 0, 0, 1, 1]
+            mock_time.sleep.return_value = None
+            mock_response = MagicMock()
+            mock_response.json.return_value = sample_organization_response
+            mock_response.raise_for_status.return_value = None
+            mock_session = MagicMock()
+            mock_session.get.return_value = mock_response
+            mock_httpx.return_value.__enter__.return_value = mock_session
+
+            client = Handelsregister(api_key="x", rate_limit=1)
+            client.fetch_organization(q="A")
+            client.fetch_organization(q="B")
+            mock_time.sleep.assert_called()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -112,8 +112,8 @@ class TestEnrichIntegration:
         """Test enrich with invalid input_type."""
         client, _ = mock_client
         
-        with pytest.raises(ValueError, match="enrich\\(\\) currently only supports 'json' input_type"):
-            client.enrich(file_path="test.csv", input_type="csv")
+        with pytest.raises(ValueError, match="enrich() supports only"):
+            client.enrich(file_path="test.csv", input_type="bad")
 
     def test_missing_file_path(self, mock_client):
         """Test enrich with missing file_path."""
@@ -121,6 +121,65 @@ class TestEnrichIntegration:
         
         with pytest.raises(ValueError, match="file_path is required for enrich\\(\\)"):
             client.enrich(input_type="json")
+    def test_enrich_csv(self, mock_client, sample_csv_file, snapshot_directory, sample_organization_response):
+        client, mock_httpx = mock_client
+        mock_response = MagicMock()
+        mock_response.json.return_value = sample_organization_response
+        mock_response.raise_for_status.return_value = None
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_response
+        mock_httpx.return_value.__enter__.return_value = mock_session
+
+        out_file = os.path.join(snapshot_directory, "out.csv")
+        client.enrich(
+            file_path=sample_csv_file,
+            input_type="csv",
+            output_path=out_file,
+            output_type="csv",
+            query_properties={"name": "company_name", "location": "city"},
+            snapshot_dir=snapshot_directory,
+        )
+        assert mock_session.get.call_count == 3
+        assert os.path.exists(out_file)
+
+    def test_enrich_xlsx(self, mock_client, sample_xlsx_file, snapshot_directory, sample_organization_response):
+        client, mock_httpx = mock_client
+        mock_response = MagicMock()
+        mock_response.json.return_value = sample_organization_response
+        mock_response.raise_for_status.return_value = None
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_response
+        mock_httpx.return_value.__enter__.return_value = mock_session
+
+        out_file = os.path.join(snapshot_directory, "out.xlsx")
+        client.enrich(
+            file_path=sample_xlsx_file,
+            input_type="xlsx",
+            output_path=out_file,
+            output_type="xlsx",
+            query_properties={"name": "company_name", "location": "city"},
+            snapshot_dir=snapshot_directory,
+        )
+        assert mock_session.get.call_count == 3
+        assert os.path.exists(out_file)
+
+    def test_enrich_default_output(self, mock_client, sample_csv_file, snapshot_directory, sample_organization_response):
+        client, mock_httpx = mock_client
+        mock_response = MagicMock()
+        mock_response.json.return_value = sample_organization_response
+        mock_response.raise_for_status.return_value = None
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_response
+        mock_httpx.return_value.__enter__.return_value = mock_session
+
+        expected_out = sample_csv_file.replace(".csv", "_handelsregister_ai_enriched.csv")
+        client.enrich(
+            file_path=sample_csv_file,
+            input_type="csv",
+            query_properties={"name": "company_name", "location": "city"},
+            snapshot_dir=snapshot_directory,
+        )
+        assert os.path.exists(expected_out)
 
 
 @patch('httpx.Client')


### PR DESCRIPTION
## Summary
- replace search with `fetch` command
- allow selecting fields to display
- add output formatting and default enriched file name
- bump package version to 0.2
- document new CLI usage in README
- update tests for new CLI options

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*