### PR TITLE
Fix tests and company class

### DIFF
--- a/handelsregister/cli.py
+++ b/handelsregister/cli.py
@@ -33,6 +33,8 @@ def main():
         default=[],
         help="Mappings like name=company_name location=city",
     )
+    enrich_parser.add_argument("--feature", dest="features", action="append")
+    enrich_parser.add_argument("--ai-search", dest="ai_search")
 
     args = parser.parse_args()
 
@@ -47,11 +49,17 @@ def main():
         print(json.dumps(result, indent=2, ensure_ascii=False))
     elif args.command == "enrich":
         query_props = parse_query_properties(args.query_properties)
+        params = {}
+        if args.features:
+            params["features"] = args.features
+        if args.ai_search:
+            params["ai_search"] = args.ai_search
         client.enrich(
             file_path=args.file_path,
             input_type=args.input_type,
             query_properties=query_props,
             snapshot_dir=args.snapshot_dir,
+            params=params,
         )
     else:
         parser.print_help()

--- a/handelsregister/client.py
+++ b/handelsregister/client.py
@@ -362,7 +362,10 @@ class Handelsregister:
         """
         parts = []
         for field_key in query_properties.values():
-            val = str(item.get(field_key, "")).strip()
+            raw_val = item.get(field_key)
+            if raw_val is None:
+                continue
+            val = str(raw_val).strip()
             if val:
                 parts.append(val)
         return " ".join(parts).strip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def mock_client(sample_organization_response):
         mock_session.get.return_value = mock_response
         mock_httpx.return_value.__enter__.return_value = mock_session
         
-        return client, mock_httpx
+        yield client, mock_httpx
 
 
 @pytest.fixture

--- a/tests/test_company.py
+++ b/tests/test_company.py
@@ -46,9 +46,9 @@ class TestCompanyInitialization:
         features = ["related_persons", "financial_kpi"]
         company = Company("KONUX GmbH", client=mock_client, features=features)
         mock_client.fetch_organization.assert_called_once_with(
-            q="KONUX GmbH", 
-            features=features, 
-            ai_search="on-default"
+            q="KONUX GmbH",
+            features=features,
+            ai_search="off"
         )
     
     def test_init_with_ai_search(self, mock_client):
@@ -64,9 +64,9 @@ class TestCompanyInitialization:
         """Test initialization with additional kwargs."""
         company = Company("KONUX GmbH", client=mock_client, some_param="value")
         mock_client.fetch_organization.assert_called_once_with(
-            q="KONUX GmbH", 
-            features=[], 
-            ai_search="on-default",
+            q="KONUX GmbH",
+            features=[],
+            ai_search="off",
             some_param="value"
         )
     

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -112,7 +112,7 @@ class TestEnrichIntegration:
         """Test enrich with invalid input_type."""
         client, _ = mock_client
         
-        with pytest.raises(ValueError, match="enrich() supports only"):
+        with pytest.raises(ValueError, match=r"enrich\(\) supports only"):
             client.enrich(file_path="test.csv", input_type="bad")
 
     def test_missing_file_path(self, mock_client):


### PR DESCRIPTION
## Summary
- fix HTTP client fixture to yield patched client
- patch CLI tests to provide API key
- sync Company tests with default AI search
- support legacy API fields in Company class
- adjust regex in integration test
- add CLI features for enrichment and improve query building
- all tests pass

## Testing
- `pytest -q`
