### PR TITLE
Improve CLI docs and snapshot handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,15 @@ client.enrich(
 
 ## 🖥️ Command Line Interface
 
-You can also use a small CLI after installing the package:
+You can also use a small CLI after installing the package.
+Use the `fetch` subcommand for a single company lookup and `enrich` to
+process a file of companies.
 
 ```bash
 $ handelsregister fetch "KONUX GmbH München"
+KONUX GmbH | Status: ACTIVE | Reg: München 210918 | Flößergasse 2, 81369 München, DEU
+
+$ handelsregister fetch json "KONUX GmbH München"
 {
   "name": "KONUX GmbH",
   "registration": {"register_number": "210918"},
@@ -138,6 +143,7 @@ $ handelsregister fetch "KONUX GmbH München"
 $ handelsregister enrich companies.csv --input csv \
     --query-properties name=company_name location=city \
     --snapshot-dir snapshots \
+    --feature related_persons --feature financial_kpi \
     --output-format csv
 ```
 

--- a/handelsregister/cli.py
+++ b/handelsregister/cli.py
@@ -19,7 +19,7 @@ def main():
     subparsers = parser.add_subparsers(dest="command")
 
     fetch_parser = subparsers.add_parser("fetch", help="Fetch a company")
-    fetch_parser.add_argument("query")
+    fetch_parser.add_argument("query", nargs="+")
     fetch_parser.add_argument("--feature", dest="features", action="append")
     fetch_parser.add_argument("--ai-search", dest="ai_search")
 
@@ -43,12 +43,21 @@ def main():
     client = Handelsregister()
 
     if args.command == "fetch":
+        query_parts = list(args.query)
+        output_json = False
+        if query_parts and query_parts[0].lower() == "json":
+            output_json = True
+            query_parts = query_parts[1:]
+        query_string = " ".join(query_parts)
         result = client.fetch_organization(
-            q=args.query,
+            q=query_string,
             features=args.features,
             ai_search=args.ai_search,
         )
-        print(json.dumps(result, indent=2, ensure_ascii=False))
+        if output_json:
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        else:
+            print(client._format_flat_result(result))
     elif args.command == "enrich":
         query_props = parse_query_properties(args.query_properties)
         params = {}

--- a/handelsregister/version.py
+++ b/handelsregister/version.py
@@ -2,4 +2,4 @@
 Versionsinformationen für das Handelsregister AI SDK.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "handelsregister"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python SDK für den Zugriff auf die Handelsregister AI API"
 readme = "README.md"
 authors = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+import sys
+import json
+from unittest.mock import patch
+
+from handelsregister.cli import main as cli_main
+from handelsregister.client import Handelsregister
+
+
+def test_fetch_json(capsys, sample_organization_response, monkeypatch):
+    def fake_fetch(self, q, features=None, ai_search=None):
+        return sample_organization_response
+
+    monkeypatch.setattr(Handelsregister, "fetch_organization", fake_fetch)
+    monkeypatch.setenv("HANDELSREGISTER_API_KEY", "x")
+    monkeypatch.setattr(sys, "argv", ["prog", "fetch", "json", "KONUX GmbH"])
+    cli_main()
+    out = capsys.readouterr().out
+    assert json.loads(out) == sample_organization_response
+
+
+def test_fetch_text(capsys, sample_organization_response, monkeypatch):
+    def fake_fetch(self, q, features=None, ai_search=None):
+        return sample_organization_response
+
+    monkeypatch.setattr(Handelsregister, "fetch_organization", fake_fetch)
+    monkeypatch.setenv("HANDELSREGISTER_API_KEY", "x")
+    monkeypatch.setattr(sys, "argv", ["prog", "fetch", "KONUX GmbH"])
+    cli_main()
+    out = capsys.readouterr().out.strip()
+    assert "KONUX GmbH" in out
+    assert "Status: ACTIVE" in out

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,7 +68,10 @@ class TestEnrichIntegration:
         ]
         
         os.makedirs(snapshot_directory, exist_ok=True)
-        with open(os.path.join(snapshot_directory, "snapshot_20230101_120000.json"), 'w') as f:
+        with open(
+            os.path.join(snapshot_directory, "snapshot_noparams_20230101_120000.json"),
+            'w'
+        ) as f:
             json.dump(existing_data, f)
         
         # Configure the mock for new API calls


### PR DESCRIPTION
## Summary
- document `handelsregister enrich` usage in README
- version bump to 0.2.0
- track enrichment parameters in snapshot filenames
- adjust tests for new snapshot naming
- support `fetch` command with human-readable output and `fetch json` for raw output

## Testing
- `pytest -q`