### PR TITLE
Increase default API timeout

### DIFF
--- a/handelsregister/client.py
+++ b/handelsregister/client.py
@@ -36,7 +36,7 @@ class Handelsregister:
     def __init__(
         self,
         api_key: Optional[str] = None,
-        timeout: float = 10.0,
+        timeout: float = 90.0,
         base_url: str = BASE_URL,
         cache_enabled: bool = True,
         rate_limit: float = 0.0,


### PR DESCRIPTION
## Summary
- default timeout increased from 10 to 90 seconds

## Testing
- `pytest -q`